### PR TITLE
[Feature/embedding] 외부 API 호출 E2E 테스트 , Embedding 관련 VO, Model 주입 구조 refactoring 

### DIFF
--- a/Closet-Saver/closet-saver/.gitignore
+++ b/Closet-Saver/closet-saver/.gitignore
@@ -33,6 +33,7 @@ out/
 /nbdist/
 /.nb-gradle/
 
+
 ### VS Code ###
 .vscode/
 
@@ -40,3 +41,6 @@ out/
 ### env ###
 .env
 
+
+src/main/resources/*.yml
+!application.yml

--- a/Closet-Saver/closet-saver/build.gradle
+++ b/Closet-Saver/closet-saver/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation("com.squareup.okhttp3:okhttp:4.11.0")
 }
 
 tasks.named('test') {

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/closet/model/ClosetItem.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/closet/model/ClosetItem.java
@@ -1,78 +1,84 @@
-package com.cholog_ai.closet_saver.domain.closet.model;
-
-import com.cholog_ai.closet_saver.domain.closet.model.vo.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-
-@Getter
-@NoArgsConstructor
-public class ClosetItem {
-
-    private Long id;                // 옷 식별자
-    private String imageUrl;        // 이미지 경로
-
-    private Category category;
-    private Season season;
-    private Color color;
-    private Material material;
-    private Style style;
-
-    private double[] embedding;     // 이미지 임베딩
-
-    public ClosetItem(
-            Long id,
-            String imageUrl,
-            Color color,
-            Category category,
-            Season season,
-            Material material,
-            Style style,
-            double[] embedding
-    ) {
-        this.id = id;
-        this.imageUrl = imageUrl;
-        this.color = color;
-        this.category = category;
-        this.season = season;
-        this.material = material;
-        this.style = style;
-        this.embedding = embedding;
-    }
-
-    // --- 도메인 행동 (Business Logic) ---
-
-    /** 특정 속성이 일치하는지 */
-    public boolean matchesColor(Color other) {
-        return this.color.equals(other);
-    }
-
-    public boolean matchesCategory(Category other) {
-        return this.category.equals(other);
-    }
-
-    public boolean matchesSeason(Season other) {
-        return this.season.equals(other);
-    }
-
-    public boolean matchesMaterial(Material other) {
-        return this.material.equals(other);
-    }
-
-    public boolean matchesStyle(Style other) {
-        return this.style.equals(other);
-    }
-
-    /** 속성 기반 유사도 계산을 위한 벡터 생성 (one-hot or normalized) */
-    public double[] toAttributeVector() {
-        return new double[]{
-                color.getIndex(),
-                category.getIndex(),
-                season.getIndex(),
-                material.getIndex(),
-                style.getIndex()
-        };
-    }
-}
-
-
+//package com.cholog_ai.closet_saver.domain.closet.model;
+//
+//
+//import com.cholog_ai.closet_saver.domain.closet.model.vo.Material;
+//import com.cholog_ai.closet_saver.domain.closet.model.vo.Season;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//
+//@Getter
+//@NoArgsConstructor
+//=======
+//// pr 기준
+//// 모르겠티비
+//
+//>>>>>>> Stashed changes
+//public class ClosetItem {
+//
+//    private Long id;                // 옷 식별자
+//    private String imageUrl;        // 이미지 경로
+//
+//    private Category category;
+//    private Season season;
+//    private Color color;
+//    private Material material;
+//    private Style style;
+//
+//    private double[] embedding;     // 이미지 임베딩
+//
+//    public ClosetItem(
+//            Long id,
+//            String imageUrl,
+//            Color color,
+//            Category category,
+//            Season season,
+//            Material material,
+//            Style style,
+//            double[] embedding
+//    ) {
+//        this.id = id;
+//        this.imageUrl = imageUrl;
+//        this.color = color;
+//        this.category = category;
+//        this.season = season;
+//        this.material = material;
+//        this.style = style;
+//        this.embedding = embedding;
+//    }
+//
+//    // --- 도메인 행동 (Business Logic) ---
+//
+//    /** 특정 속성이 일치하는지 */
+//    public boolean matchesColor(Color other) {
+//        return this.color.equals(other);
+//    }
+//
+//    public boolean matchesCategory(Category other) {
+//        return this.category.equals(other);
+//    }
+//
+//    public boolean matchesSeason(Season other) {
+//        return this.season.equals(other);
+//    }
+//
+//    public boolean matchesMaterial(Material other) {
+//        return this.material.equals(other);
+//    }
+//
+//    public boolean matchesStyle(Style other) {
+//        return this.style.equals(other);
+//    }
+//
+//    /** 속성 기반 유사도 계산을 위한 벡터 생성 (one-hot or normalized) */
+//    public double[] toAttributeVector() {
+//        return new double[]{
+//                color.getIndex(),
+//                category.getIndex(),
+//                season.getIndex(),
+//                material.getIndex(),
+//                style.getIndex()
+//        };
+//    }
+//}
+//
+//

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/closet/repository/ClosetJsonRepository.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/closet/repository/ClosetJsonRepository.java
@@ -1,54 +1,52 @@
-package com.cholog_ai.closet_saver.domain.closet.repository;
-
-import com.cholog_ai.closet_saver.domain.closet.model.ClosetItem;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.PostConstruct;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Repository;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-@Profile("dev") // dev시에만 Mock Data를 위해 사용할 레포
-@Repository
-@Slf4j
-public class ClosetJsonRepository implements ClosetRepository{
-    private final List<ClosetItem> closetItems = new ArrayList<>();
-
-    @Override
-    public List<ClosetItem> findAll() {
-        return new ArrayList<>(closetItems);
-    }
-
-    @Override
-    public Optional<ClosetItem> findById(Long id) {
-        return closetItems.stream()
-                .filter(item -> item.getId().equals(id))
-                .findFirst();
-    }
-
-    @PostConstruct // 서버 시작 시 Json 파일 로딩
-    @Override
-    public void loadInitialData() {
-        try{
-            ObjectMapper mapper = new ObjectMapper();
-            InputStream is = getClass().getResourceAsStream("/mock/closet.json");
-
-
-            // deserialize json data
-            List<ClosetItem> items = mapper.readValue(
-                    is,
-                    new TypeReference<List<ClosetItem>>() {}
-            );
-            closetItems.addAll(items);
-            log.info("Closet JSON Loaded : {} items", closetItems.size());
-
-        }catch (Exception e){
-            log.error("Failed to load JSON", e);
-        }
-    }
-}
+//package com.cholog_ai.closet_saver.domain.closet.repository;
+//
+//import com.cholog_ai.closet_saver.domain.closet.model.ClosetItem;
+//import com.fasterxml.jackson.core.type.TypeReference;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import jakarta.annotation.PostConstruct;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.context.annotation.Profile;
+//import org.springframework.stereotype.Repository;
+//
+//import java.io.InputStream;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Optional;
+//
+//@Profile("dev") // dev시에만 Mock Data를 위해 사용할 레포
+//@Repository
+//@Slf4j
+//public class ClosetJsonRepository implements ClosetRepository{
+//    private final List<ClosetItem> closetItems = new ArrayList<>();
+//
+//    @Override
+//    public List<ClosetItem> findAll() {
+//        return new ArrayList<>(closetItems);
+//    }
+//
+//    @Override
+//    public Optional<ClosetItem> findById(Long id) {
+//        return closetItems.stream()
+//                .filter(item -> item.getId().equals(id))
+//                .findFirst();
+//    }
+//
+//    @PostConstruct // 서버 시작 시 Json 파일 로딩
+//    @Override
+//    public void loadInitialData() {
+//        try{
+//            ObjectMapper mapper = new ObjectMapper();
+//            InputStream is = getClass().getResourceAsStream("/mock/closet.json");
+//            // deserialize json data
+//            List<ClosetItem> items = mapper.readValue(
+//                    is,
+//                    new TypeReference<List<ClosetItem>>() {}
+//            );
+//            closetItems.addAll(items);
+//            log.info("Closet JSON Loaded : {} items", closetItems.size());
+//
+//        }catch (Exception e){
+//            log.error("Failed to load JSON", e);
+//        }
+//    }
+//}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/closet/repository/ClosetRepository.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/closet/repository/ClosetRepository.java
@@ -1,12 +1,12 @@
-package com.cholog_ai.closet_saver.domain.closet.repository;
-
-import com.cholog_ai.closet_saver.domain.closet.model.ClosetItem;
-
-import java.util.List;
-import java.util.Optional;
-
-public interface ClosetRepository {
-    List<ClosetItem> findAll();
-    Optional<ClosetItem> findById(Long id);
-    void loadInitialData();
-}
+//package com.cholog_ai.closet_saver.domain.closet.repository;
+//
+//import com.cholog_ai.closet_saver.domain.closet.model.ClosetItem;
+//
+//import java.util.List;
+//import java.util.Optional;
+//
+//public interface ClosetRepository {
+//    List<ClosetItem> findAll();
+//    Optional<ClosetItem> findById(Long id);
+//    void loadInitialData();
+//}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/config/EmbeddingModelConfig.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/config/EmbeddingModelConfig.java
@@ -1,0 +1,8 @@
+package com.cholog_ai.closet_saver.domain.embedding.config;
+
+public interface EmbeddingModelConfig {
+    String getUrl();
+    String getModelName();
+    String getEncodingFormat();
+    String getKey();
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/config/OpenAiEmbeddingModelConfig.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/config/OpenAiEmbeddingModelConfig.java
@@ -1,0 +1,32 @@
+package com.cholog_ai.closet_saver.domain.embedding.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenAiEmbeddingModelConfig implements EmbeddingModelConfig{
+
+    @Value("${openai.key}")
+    private String API_KEY;
+
+    @Override
+    public String getUrl() {
+        return "https://api.openai.com/v1/embeddings";
+    }
+
+    @Override
+    public String getModelName() {
+        return "text-embedding-3-small";
+    }
+
+    @Override
+    public String getEncodingFormat() {
+        return "float";
+    }
+
+    @Override
+    public String getKey() {
+        return API_KEY;
+    }
+
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/EmbeddingResponse.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/EmbeddingResponse.java
@@ -1,0 +1,15 @@
+package com.cholog_ai.closet_saver.domain.embedding.model.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class EmbeddingResponse {
+    private List<EmbeddingData> data;
+    @Data
+    public static class EmbeddingData{
+        private List<Double> embedding;
+        private int index;
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/EmbeddingResponse.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/EmbeddingResponse.java
@@ -1,14 +1,19 @@
 package com.cholog_ai.closet_saver.domain.embedding.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EmbeddingResponse {
+
     private List<EmbeddingData> data;
+
     @Data
-    public static class EmbeddingData{
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class EmbeddingData {
         private List<Double> embedding;
         private int index;
     }

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/vo/EmbeddingType.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/vo/EmbeddingType.java
@@ -1,0 +1,7 @@
+package com.cholog_ai.closet_saver.domain.embedding.model.vo;
+
+public enum EmbeddingType {
+
+    IMAGE,
+    TEXT
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/vo/EmbeddingValue.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/vo/EmbeddingValue.java
@@ -1,0 +1,66 @@
+package com.cholog_ai.closet_saver.domain.embedding.model.vo;
+import lombok.Builder;
+
+import java.util.Map;
+public class EmbeddingValue {
+    private final double[] vector;
+    private final EmbeddingType type;
+    private static final Map<EmbeddingType, Integer> DIMENSION_RULE = Map.of(
+            EmbeddingType.TEXT,1536,
+            EmbeddingType.IMAGE,512
+    );
+    @Builder
+    public EmbeddingValue(final double[] vector, final EmbeddingType type) {
+        validateDimensionOfVector(vector,type);
+        this.vector = vector;
+        this.type = type;
+    }
+    public double[] getVector(){
+        return vector.clone();
+    }
+    public EmbeddingType getType(){
+        return type;
+    }
+
+    public double calculateSimilarity(EmbeddingValue other){
+
+        if (other.getType() != this.getType()){
+            throw new IllegalArgumentException("일치하는 타입의 임베딩 값에 대한 유사도만 계산 가능합니다.");
+        }
+
+        if (other.getVector() == null || other.getVector().length == 0){
+            throw new IllegalArgumentException("비교하고자 하는 EmbeddingValue의 vector 값은 비어있거나 길이가 0이면 안됩니다.");
+        }
+
+        if(other.getVector().length != this.vector.length) {
+            throw new IllegalArgumentException("벡터의 길이가 다르면 유사도 계산을 진행할 수 없습니다.");
+        }
+
+        return cosineSimilarity(this.vector, other.getVector());
+    }
+
+    private double cosineSimilarity(double[] a, double[] b){
+        double dot = 0, normA = 0, normB = 0;
+        for(int i=0; i<a.length; i++){
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+        return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+
+    private void validateDimensionOfVector(double[] vector, final EmbeddingType type){
+        if (vector == null || vector.length == 0){
+            throw new IllegalArgumentException("vector는 비어있을 수 없습니다.");
+        }
+
+        int expectedDimension = DIMENSION_RULE.get(type);
+        if(vector.length != expectedDimension){
+            throw new IllegalArgumentException(
+                    "Embedding 길이가 맞지 않습니다. type=" + type +
+                            ", expected=" + expectedDimension +
+                            ", actual=" + vector.length
+            );
+        }
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/vo/EmbeddingValue.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/vo/EmbeddingValue.java
@@ -1,7 +1,10 @@
 package com.cholog_ai.closet_saver.domain.embedding.model.vo;
 import lombok.Builder;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
+
 public class EmbeddingValue {
     private final double[] vector;
     private final EmbeddingType type;
@@ -62,5 +65,19 @@ public class EmbeddingValue {
                             ", actual=" + vector.length
             );
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EmbeddingValue that)) return false;
+        return Arrays.equals(getVector(), that.getVector()) && getType() == that.getType();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(getType());
+        result = 31 * result + Arrays.hashCode(getVector());
+        return result;
     }
 }

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
@@ -1,5 +1,6 @@
 package com.cholog_ai.closet_saver.domain.embedding.service;
 
+import com.cholog_ai.closet_saver.domain.embedding.config.EmbeddingModelConfig;
 import com.cholog_ai.closet_saver.domain.embedding.model.dto.EmbeddingResponse;
 import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
 import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
@@ -7,7 +8,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -19,18 +19,19 @@ import java.util.Map;
 public class TextEmbeddingService {
 
     // TODO : unit, 통합 test 작성
-    private static final String EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
+    private final String EMBEDDING_URL;
     // small : 1536, large : 3072
-    private static final String MODEL_NAME = "text-embedding-3-small";
-
-    @Value("${openai.key}")
-    private String API_KEY;
+    private final String API_KEY;
     private final OkHttpClient client = new OkHttpClient();
     private final ObjectMapper mapper = new ObjectMapper();
-    private static final Map<String,Object> BASE_BODY = Map.of(
-            "model",MODEL_NAME,
-            "encoding_format","float"
-            );
+    private static final Map<String,Object> BASE_BODY = new HashMap<>();
+
+    public TextEmbeddingService(EmbeddingModelConfig config){
+        EMBEDDING_URL = config.getUrl();
+        API_KEY = config.getKey();
+        BASE_BODY.put("model",config.getModelName());
+        BASE_BODY.put("encoding_format",config.getEncodingFormat());
+    }
     /*
     * 텍스트를 OpenAI 임베딩 API를 사용해서 double 배열로 변환함.
      */
@@ -44,7 +45,7 @@ public class TextEmbeddingService {
 
             Request request = new Request.Builder()
                     .url(EMBEDDING_URL)
-                    .header("Authorization", "Bearer" + API_KEY)
+                    .header("Authorization", "Bearer " + API_KEY)
                     .post(body)
                     .build();
 

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
@@ -1,6 +1,8 @@
 package com.cholog_ai.closet_saver.domain.embedding.service;
 
 import com.cholog_ai.closet_saver.domain.embedding.model.dto.EmbeddingResponse;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +17,6 @@ import java.util.Map;
 @Service
 @Slf4j
 public class TextEmbeddingService {
-
 
     // TODO : unit, 통합 test 작성
     private static final String EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
@@ -33,10 +34,9 @@ public class TextEmbeddingService {
     /*
     * 텍스트를 OpenAI 임베딩 API를 사용해서 double 배열로 변환함.
      */
-    public double[] embedText(String text){
+    public EmbeddingValue embedText(String text){
         try {
             String requestJson = buildRequestJson(text);
-
             RequestBody body = RequestBody.create(
                     requestJson,
                     MediaType.parse("application/json")
@@ -51,7 +51,6 @@ public class TextEmbeddingService {
             Response response = client.newCall(request).execute();
             String responseBody = response.body().string();
 
-
             if (!response.isSuccessful()) {
                 log.error("OpenAI Embedding API Error: {}", responseBody);
                 throw new RuntimeException("Embedding API 호출 실패"); // Todo : Exception, error code 커스텀
@@ -60,9 +59,10 @@ public class TextEmbeddingService {
             EmbeddingResponse embeddingResponse = mapper.readValue(responseBody, EmbeddingResponse.class);
             List<Double> embeddingList = embeddingResponse.getData().get(0).getEmbedding();
 
-            return embeddingList.stream()
-                    .mapToDouble(Double::doubleValue)
-                    .toArray();
+            return EmbeddingValue.builder()
+                    .vector(embeddingList.stream().mapToDouble(Double::doubleValue).toArray())
+                    .type(EmbeddingType.TEXT)
+                    .build();
 
         } catch(Exception e){
             log.error("텍스트 임베딩 실패: {}", e.getMessage());

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
@@ -1,0 +1,78 @@
+package com.cholog_ai.closet_saver.domain.embedding.service;
+
+import com.cholog_ai.closet_saver.domain.embedding.model.dto.EmbeddingResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class TextEmbeddingService {
+
+
+    // TODO : unit, 통합 test 작성
+    private static final String EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
+    // small : 1536, large : 3072
+    private static final String MODEL_NAME = "text-embedding-3-small";
+
+    @Value("${openai.key}")
+    private String API_KEY;
+    private final OkHttpClient client = new OkHttpClient();
+    private final ObjectMapper mapper = new ObjectMapper();
+    private static final Map<String,Object> BASE_BODY = Map.of(
+            "model",MODEL_NAME,
+            "encoding_format","float"
+            );
+    /*
+    * 텍스트를 OpenAI 임베딩 API를 사용해서 double 배열로 변환함.
+     */
+    public double[] embedText(String text){
+        try {
+            String requestJson = buildRequestJson(text);
+
+            RequestBody body = RequestBody.create(
+                    requestJson,
+                    MediaType.parse("application/json")
+            );
+
+            Request request = new Request.Builder()
+                    .url(EMBEDDING_URL)
+                    .header("Authorization", "Bearer" + API_KEY)
+                    .post(body)
+                    .build();
+
+            Response response = client.newCall(request).execute();
+            String responseBody = response.body().string();
+
+
+            if (!response.isSuccessful()) {
+                log.error("OpenAI Embedding API Error: {}", responseBody);
+                throw new RuntimeException("Embedding API 호출 실패"); // Todo : Exception, error code 커스텀
+            }
+
+            EmbeddingResponse embeddingResponse = mapper.readValue(responseBody, EmbeddingResponse.class);
+            List<Double> embeddingList = embeddingResponse.getData().get(0).getEmbedding();
+
+            return embeddingList.stream()
+                    .mapToDouble(Double::doubleValue)
+                    .toArray();
+
+        } catch(Exception e){
+            log.error("텍스트 임베딩 실패: {}", e.getMessage());
+            throw new RuntimeException("텍스트 임베딩 중 오류 발생"); // Todo : Exception, error code 커스텀
+        }
+    }
+
+    private String buildRequestJson(String text) throws JsonProcessingException {
+        Map<String,Object> body = new HashMap<>(BASE_BODY);
+        body.put("input",text);
+        return mapper.writeValueAsString(body);
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/resources/application.yml
+++ b/Closet-Saver/closet-saver/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   config:
     import: optional:file:.env[.properties]
-
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://127.0.0.1:${MYSQL_PORT}/closet_saver?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
@@ -12,3 +11,9 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+
+
+openai:
+  key: ${OPENAI_KEY}
+
+

--- a/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/ClosetSaverApplicationTests.java
+++ b/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/ClosetSaverApplicationTests.java
@@ -1,13 +1,13 @@
-//package com.cholog_ai.closet_saver;
-//
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//@SpringBootTest
-//class ClosetSaverApplicationTests {
-//
-//	@Test
-//	void contextLoads() {
-//	}
-//
-//}
+package com.cholog_ai.closet_saver;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ClosetSaverApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/e2e/TextEmbeddingServiceE2ETest.java
+++ b/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/e2e/TextEmbeddingServiceE2ETest.java
@@ -1,0 +1,39 @@
+package com.cholog_ai.closet_saver.e2e;
+
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
+import com.cholog_ai.closet_saver.domain.embedding.service.TextEmbeddingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class TextEmbeddingServiceE2ETest {
+
+    @Autowired
+    private TextEmbeddingService textEmbeddingService;
+
+    // TODO : 매번 돌릴 필요 없는 test이므로 CI/CD 시에, test에서 제외할 수 있도록 하기.
+    @Test
+    void embedText_realOpenAI_success() {
+
+        // given
+        String inputText = "Hello world! This is an E2E test.";
+
+        // when
+        EmbeddingValue result = textEmbeddingService.embedText(inputText);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getType()).isEqualTo(EmbeddingType.TEXT);
+
+        // text-embedding-3-small → 1536차원
+        assertThat(result.getVector().length)
+                .isGreaterThan(100)           // 최소 길이 검증
+                .isEqualTo(1536);             // 정확한 길이 검증
+
+        System.out.println("Embedding dimension = " + result.getVector().length);
+    }
+}

--- a/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/e2e/TextEmbeddingServiceE2ETest.java
+++ b/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/e2e/TextEmbeddingServiceE2ETest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 public class TextEmbeddingServiceE2ETest {
 
+
+    // Todo : 후에 unit test용 EmbeddingConfig 구현체를 구현하면 빈충돌이 발생하므로 test용 config 분리 등록하기
     @Autowired
     private TextEmbeddingService textEmbeddingService;
 

--- a/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/unit/EmbeddingTest.java
+++ b/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/unit/EmbeddingTest.java
@@ -1,0 +1,6 @@
+package com.cholog_ai.closet_saver.unit;
+
+public class EmbeddingTest {
+
+
+}


### PR DESCRIPTION
#  Embedding 기능, test 구현 및 구조 개선

## Summary

이번 PR에서는 OpenAI Text Embedding 기능 수정하고
이를 테스트하기 위해 Embed 모델 config 요소를 인터페이스로 분리 및 구조 리팩토링을 진행했습니다.
또한 Embedding Value에 대한 유효성 검사를 VO 내에서 자체적으로 진행하는 구조로 만들기 위한 VO를 추가하였습니다. 
향후 테스트 전략을 정돈하기 위한 TODO도 추가했습니다.

1. TextEmbeddingService 구현

OpenAI Embedding API(text-embedding-3-small) 호출 기능 추가

입력 텍스트 기반 임베딩 벡터 생성

성공/실패 로깅 및 예외 처리 구조 구성

반환 객체로 EmbeddingValue VO 사용하도록 설계

OkHttp 기반 HTTP 요청 구현

JSON 파싱 로직(ObjectMapper) 포함

API Key 설정은 @Value 기반 환경 변수 주입 방식 사용

2. VO(EmbeddingValue)의 equals(), hashCode() 추가 및 유효성 검사 진행

임베딩 벡터의 동등성 비교를 위해 equals, hashCode 구현 - 당장은 필요없지만 향후 캐싱 등에 사용될 수 있다고 예상 

내부적으 매개변수의 유효성 검증 로직 추가 

3. Embedding 모델 인터페이스 분리 및 리팩토링

TextEmbeddingService가 특정 모델이나 설정에 강하게 결합되지 않도록
EmbeddingModelConfig 인터페이스를 분리

모델명, URL, API_KEY 등의 외부 모델 관련 설정을 인터페이스로 추상화 -> 테스트 가능성과 확장성을 고려한 구조 개선


##  Test 전략 
✔ Unit Test (예정)

OpenAI API를 직접 호출하지 않음

FakeConfig + mock OkHttpClient를 사용하여 순수 비즈니스 로직 테스트

EmbeddingModelConfig 인터페이스 분리로 손쉽게 테스트 가능해짐

✔ E2E Test (구현 완료)

실제 OpenAI Embedding API 호출

dimension(1536) 검증

테스트 키가 필요하고 매번 테스트할 필요가 없으므로 CI에서는 제외할 예정

✔ 향후 개선 (예정)

prod/test profile 분리

Config 빈 충돌 방지

TestConfig를 테스트 전용으로 제공