### PR TITLE
[Feature/embedding] ImageEmbeddingService, unit test 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,13 +6,19 @@ enable_free_tier: true
 reviews:
   profile: chill
   high_level_summary: true
-  high_level_summary_placeholder: @coderabbitai summary
+  high_level_summary_placeholder: "@coderabbitai summary"
 
   auto_title_placeholder: "@coderabbitai"
 
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+        - "main"
+        - "develop"
+        - "feature/**"
+
+
   # update to the tools you use, see full list: https://docs.coderabbit.ai/tools/list
   tools:
     eslint:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,6 @@ reviews:
     base_branches:
         - "main"
         - "develop"
-        - "feature/**"
 
 
   # update to the tools you use, see full list: https://docs.coderabbit.ai/tools/list

--- a/Closet-Saver/.idea/vcs.xml
+++ b/Closet-Saver/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/Closet-Saver/closet-saver/build.gradle
+++ b/Closet-Saver/closet-saver/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation("com.squareup.okhttp3:okhttp:4.11.0")
+	implementation("com.squareup.okhttp3:mockwebserver:4.11.0")
 }
 
 tasks.named('test') {

--- a/Closet-Saver/closet-saver/build.gradle
+++ b/Closet-Saver/closet-saver/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation("com.squareup.okhttp3:okhttp:4.11.0")
-	implementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+	testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
 }
 
 tasks.named('test') {

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/ImageEmbeddingResponse.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/ImageEmbeddingResponse.java
@@ -1,0 +1,6 @@
+package com.cholog_ai.closet_saver.domain.embedding.model.dto;
+
+import java.util.List;
+
+public record ImageEmbeddingResponse(List<Double> embeddingVector) {
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/TextEmbeddingResponse.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/model/dto/TextEmbeddingResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class EmbeddingResponse {
+public class TextEmbeddingResponse {
 
     private List<EmbeddingData> data;
 

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
@@ -34,6 +34,8 @@ public class ImageEmbeddingService {
 
     public EmbeddingValue embeddingImage(MultipartFile file) {
 
+        validateInputMultiipartFile(file);
+
         try {
             RequestBody requestBody = new MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -69,6 +71,18 @@ public class ImageEmbeddingService {
         } catch (Exception e) {
             log.error(e.getMessage());
             throw new RuntimeException("이미지 임베딩 중 오류 발생", e);
+        }
+    }
+
+
+    private void validateInputMultiipartFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 null이거나 비어있습니다.");
+        }
+
+        String filename = file.getOriginalFilename();
+        if (filename.isBlank()) {
+            throw new IllegalArgumentException("파일명이 유효하지 않습니다.");
         }
     }
 }

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
@@ -15,9 +15,9 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Slf4j
 public class ImageEmbeddingService {
-
     private final OkHttpClient client = new OkHttpClient();
     private final ObjectMapper mapper = new ObjectMapper();
+
     @Value("${embedding.image.url}")
     private String imageEmbeddingUrl;
 

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
@@ -4,22 +4,33 @@ import com.cholog_ai.closet_saver.domain.embedding.model.dto.ImageEmbeddingRespo
 import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
 import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
+
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class ImageEmbeddingService {
-    private final OkHttpClient client = new OkHttpClient();
-    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final OkHttpClient client;
+    private final ObjectMapper mapper;
 
     @Value("${embedding.image.url}")
     private String imageEmbeddingUrl;
+
+    public ImageEmbeddingService(ObjectMapper mapper) {
+        this.mapper = mapper;
+        this.client = new OkHttpClient.Builder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .readTimeout(Duration.ofSeconds(10))
+                .writeTimeout(Duration.ofSeconds(10))
+                .build();
+
+    }
 
     public EmbeddingValue embeddingImage(MultipartFile file) {
 

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
@@ -18,11 +18,11 @@ public class ImageEmbeddingService {
 
     @Value("${embedding.image.url}")
     private String imageEmbeddingUrl;
-
     private final OkHttpClient client = new OkHttpClient();
     private final ObjectMapper mapper = new ObjectMapper();
 
     public EmbeddingValue embeddingImage(MultipartFile file){
+
         try{
             RequestBody requestBody = new MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -46,9 +46,10 @@ public class ImageEmbeddingService {
                 throw new RuntimeException("Image Embedding API 호출 실패");
             }
 
-            String responseBody = response.body().toString();
+            String responseBody = response.body().string();
 
             ImageEmbeddingResponse dto = mapper.readValue(responseBody, ImageEmbeddingResponse.class);
+
             double[] vector = dto.embeddingVector().stream()
                     .mapToDouble(Double::doubleValue)
                     .toArray();
@@ -56,7 +57,7 @@ public class ImageEmbeddingService {
             return new EmbeddingValue(vector, EmbeddingType.IMAGE);
 
         }catch (Exception e){
-            log.error("이미지 임베딩 처리 실패");
+            log.error(e.getMessage());
             throw new RuntimeException("이미지 임베딩 중 오류 발생",e);
         }
     }

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
@@ -1,0 +1,63 @@
+package com.cholog_ai.closet_saver.domain.embedding.service;
+
+import com.cholog_ai.closet_saver.domain.embedding.model.dto.ImageEmbeddingResponse;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageEmbeddingService {
+
+    @Value("${embedding.image.url}")
+    private String imageEmbeddingUrl;
+
+    private final OkHttpClient client = new OkHttpClient();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public EmbeddingValue embeddingImage(MultipartFile file){
+        try{
+            RequestBody requestBody = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart(
+                            "file",
+                            file.getOriginalFilename(),
+                            RequestBody.create(file.getBytes(), MediaType.parse(file.getContentType()))
+                    )
+                    .build();
+
+            Request request = new Request.Builder()
+                    .url(imageEmbeddingUrl)
+                    .post(requestBody)
+                    .build();
+
+
+            Response response = client.newCall(request).execute();
+
+            if(!response.isSuccessful()){
+                log.error("이미지 임베딩에 실패하였습니다.");
+                throw new RuntimeException("Image Embedding API 호출 실패");
+            }
+
+            String responseBody = response.body().toString();
+
+            ImageEmbeddingResponse dto = mapper.readValue(responseBody, ImageEmbeddingResponse.class);
+            double[] vector = dto.embeddingVector().stream()
+                    .mapToDouble(Double::doubleValue)
+                    .toArray();
+
+            return new EmbeddingValue(vector, EmbeddingType.IMAGE);
+
+        }catch (Exception e){
+            log.error("이미지 임베딩 처리 실패");
+            throw new RuntimeException("이미지 임베딩 중 오류 발생",e);
+        }
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/ImageEmbeddingService.java
@@ -16,14 +16,14 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class ImageEmbeddingService {
 
-    @Value("${embedding.image.url}")
-    private String imageEmbeddingUrl;
     private final OkHttpClient client = new OkHttpClient();
     private final ObjectMapper mapper = new ObjectMapper();
+    @Value("${embedding.image.url}")
+    private String imageEmbeddingUrl;
 
-    public EmbeddingValue embeddingImage(MultipartFile file){
+    public EmbeddingValue embeddingImage(MultipartFile file) {
 
-        try{
+        try {
             RequestBody requestBody = new MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
                     .addFormDataPart(
@@ -38,10 +38,9 @@ public class ImageEmbeddingService {
                     .post(requestBody)
                     .build();
 
-
             Response response = client.newCall(request).execute();
 
-            if(!response.isSuccessful()){
+            if (!response.isSuccessful()) {
                 log.error("이미지 임베딩에 실패하였습니다.");
                 throw new RuntimeException("Image Embedding API 호출 실패");
             }
@@ -56,9 +55,9 @@ public class ImageEmbeddingService {
 
             return new EmbeddingValue(vector, EmbeddingType.IMAGE);
 
-        }catch (Exception e){
+        } catch (Exception e) {
             log.error(e.getMessage());
-            throw new RuntimeException("이미지 임베딩 중 오류 발생",e);
+            throw new RuntimeException("이미지 임베딩 중 오류 발생", e);
         }
     }
 }

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
@@ -18,25 +18,25 @@ import java.util.Map;
 @Slf4j
 public class TextEmbeddingService {
 
+    private static final Map<String, Object> BASE_BODY = new HashMap<>();
     // TODO : unit, 통합 test 작성
     private final String EMBEDDING_URL;
     // small : 1536, large : 3072
     private final String API_KEY;
     private final OkHttpClient client = new OkHttpClient();
     private final ObjectMapper mapper = new ObjectMapper();
-    private static final Map<String,Object> BASE_BODY = new HashMap<>();
 
-    public TextEmbeddingService(EmbeddingModelConfig config){
+    public TextEmbeddingService(EmbeddingModelConfig config) {
         EMBEDDING_URL = config.getUrl();
         API_KEY = config.getKey();
-        BASE_BODY.put("model",config.getModelName());
-        BASE_BODY.put("encoding_format",config.getEncodingFormat());
+        BASE_BODY.put("model", config.getModelName());
+        BASE_BODY.put("encoding_format", config.getEncodingFormat());
     }
 
     /*
-    * 텍스트를 OpenAI 임베딩 API를 사용해서 double 배열로 변환함.
+     * 텍스트를 OpenAI 임베딩 API를 사용해서 double 배열로 변환함.
      */
-    public EmbeddingValue embedText(String text){
+    public EmbeddingValue embedText(String text) {
         try {
             String requestJson = buildRequestJson(text);
             RequestBody body = RequestBody.create(
@@ -66,15 +66,15 @@ public class TextEmbeddingService {
                     .type(EmbeddingType.TEXT)
                     .build();
 
-        } catch(Exception e){
+        } catch (Exception e) {
             log.error("텍스트 임베딩 실패: {}", e.getMessage());
             throw new RuntimeException("텍스트 임베딩 중 오류 발생"); // Todo : Exception, error code 커스텀
         }
     }
 
     private String buildRequestJson(String text) throws JsonProcessingException {
-        Map<String,Object> body = new HashMap<>(BASE_BODY);
-        body.put("input",text);
+        Map<String, Object> body = new HashMap<>(BASE_BODY);
+        body.put("input", text);
         return mapper.writeValueAsString(body);
     }
 }

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/embedding/service/TextEmbeddingService.java
@@ -1,7 +1,7 @@
 package com.cholog_ai.closet_saver.domain.embedding.service;
 
 import com.cholog_ai.closet_saver.domain.embedding.config.EmbeddingModelConfig;
-import com.cholog_ai.closet_saver.domain.embedding.model.dto.EmbeddingResponse;
+import com.cholog_ai.closet_saver.domain.embedding.model.dto.TextEmbeddingResponse;
 import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
 import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -32,6 +32,7 @@ public class TextEmbeddingService {
         BASE_BODY.put("model",config.getModelName());
         BASE_BODY.put("encoding_format",config.getEncodingFormat());
     }
+
     /*
     * 텍스트를 OpenAI 임베딩 API를 사용해서 double 배열로 변환함.
      */
@@ -57,8 +58,8 @@ public class TextEmbeddingService {
                 throw new RuntimeException("Embedding API 호출 실패"); // Todo : Exception, error code 커스텀
             }
 
-            EmbeddingResponse embeddingResponse = mapper.readValue(responseBody, EmbeddingResponse.class);
-            List<Double> embeddingList = embeddingResponse.getData().get(0).getEmbedding();
+            TextEmbeddingResponse textEmbeddingResponse = mapper.readValue(responseBody, TextEmbeddingResponse.class);
+            List<Double> embeddingList = textEmbeddingResponse.getData().get(0).getEmbedding();
 
             return EmbeddingValue.builder()
                     .vector(embeddingList.stream().mapToDouble(Double::doubleValue).toArray())

--- a/Closet-Saver/closet-saver/src/main/resources/application.yml
+++ b/Closet-Saver/closet-saver/src/main/resources/application.yml
@@ -12,8 +12,9 @@ spring:
       ddl-auto: update
     show-sql: true
 
-
 openai:
   key: ${OPENAI_KEY}
 
-
+embedding:
+  image:
+    url : ${IMAGE_EMBEDDING_URL}

--- a/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/unit/EmbeddingTest.java
+++ b/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/unit/EmbeddingTest.java
@@ -1,6 +1,0 @@
-package com.cholog_ai.closet_saver.unit;
-
-public class EmbeddingTest {
-
-
-}

--- a/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/unit/ImageEmbeddingServiceTest.java
+++ b/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/unit/ImageEmbeddingServiceTest.java
@@ -1,0 +1,77 @@
+package com.cholog_ai.closet_saver.unit;
+
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
+import com.cholog_ai.closet_saver.domain.embedding.service.ImageEmbeddingService;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ImageEmbeddingServiceTest {
+
+    @Autowired
+    ImageEmbeddingService imageEmbeddingService;
+    private MockWebServer mockServer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockServer = new MockWebServer();
+        mockServer.start();
+
+        // 테스트용 URL 주입
+        ReflectionTestUtils.setField(
+                imageEmbeddingService, // 대상 객체
+                "imageEmbeddingUrl", // 대상 필드
+                mockServer.url("/embed/image").toString() // 주입할 값
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockServer.shutdown();
+    }
+
+    @Test
+    void 이미지_임베딩_응답이_파싱된다() throws Exception {
+
+        List<Double> vector512 = new ArrayList<>();
+        for(int i=0; i<512; i++){
+            vector512.add(i / 1000.0);
+        }
+        String vectorJson = vector512.toString();
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody("""
+                                {
+                                    "embeddingVector" : %s
+                                }
+                                """.formatted(vectorJson)
+                        )
+                        .setResponseCode(200)
+        );
+
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.png",
+                "image/png",
+                "dummy image".getBytes()
+        );
+
+        EmbeddingValue result = imageEmbeddingService.embeddingImage(mockFile);
+        assertThat(result.getVector()).hasSize(512);
+        assertThat(result.getType()).isEqualTo(EmbeddingType.IMAGE);
+    }
+}


### PR DESCRIPTION
**What**

로컬에서 실행 중인 CLIP Image Embedding Server와의 HTTP 통신을 통해
이미지 임베딩 벡터를 가져오는 ImageEmbeddingService를 구현하였습니다.

또한, 외부 서비스 의존성을 제거한 단위 테스트(ImageEmbeddingServiceTest)를 추가했습니다.

**How**
**- mageEmbeddingService**

OkHttpClient를 사용해 로컬 CLIP 서버(/embed/image)로 이미지 파일을 전송하고,
임베딩 결과(JSON)를 수신합니다.

응답으로 받은 embeddingVector(double[])를 도메인 VO인 EmbeddingValue로 감싼 후 반환합니다.

네트워크 오류, 응답 파싱 오류 등의 상황에 대비한 예외 처리를 포함합니다.

**주요 고려 사항**

Multipart/form-data 방식으로 이미지 전송

Jackson(ObjectMapper)를 이용한 JSON → DTO 파싱

응답으로 받은 double 리스트를 double[]로 변환 후 VO로 래핑

향후 text embedding 등 다른 임베딩 타입 확장을 고려해 EmbeddingType.IMAGE 명시



**- ImageEmbeddingServiceTest**

외부 API에 의존하지 않도록 MockWebServer를 사용해 단위 테스트를 구성했습니다.

**테스트 전략**

MockWebServer 시작 후, 서비스 내부의 imageEmbeddingUrl 필드를 Reflection을 통해 mock URL로 교체

MockWebServer에 임의의 JSON 응답 삽입

MockMultipartFile을 이용해 가짜 이미지 전송

응답이 정상적으로 파싱되어 EmbeddingValue에 반영되는지 검증


**검증 포인트**

- MockServer가 설정한 벡터 값이 그대로 EmbeddingValue.vector에 매핑되는지

- EmbeddingType이 IMAGE로 설정되는지

- 통신/파싱 오류 없이 정상 동작하는지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지 업로드로 이미지 임베딩 값을 생성하는 기능이 추가되었습니다.

* **구성**
  * 이미지 임베딩용 설정 항목이 추가되고 기존 외부 키 항목이 제거되었습니다.

* **테스트**
  * 이미지 임베딩 동작을 검증하는 단위 테스트와 테스트용 의존성이 추가되었습니다.

* **기타**
  * 개발 환경 및 IDE/프로젝트 구성 파일이 일부 추가/정리되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->