### PR TITLE
Implement compare domain similarity logic

### DIFF
--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/config/SimilaritySettings.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/config/SimilaritySettings.java
@@ -1,0 +1,35 @@
+package com.cholog_ai.closet_saver.domain.compare.config;
+
+import java.util.Objects;
+
+public class SimilaritySettings {
+
+    private final SimilarityWeights weights;
+    private final int topN;
+    private final double threshold;
+
+    public SimilaritySettings(final SimilarityWeights weights, final int topN, final double threshold) {
+        if (topN <= 0) {
+            throw new IllegalArgumentException("topN must be greater than 0");
+        }
+        this.weights = Objects.requireNonNull(weights, "weights must not be null");
+        this.topN = topN;
+        this.threshold = threshold;
+    }
+
+    public static SimilaritySettings defaultSettings() {
+        return new SimilaritySettings(SimilarityWeights.defaultWeights(), 5, 0.0);
+    }
+
+    public SimilarityWeights getWeights() {
+        return weights;
+    }
+
+    public int getTopN() {
+        return topN;
+    }
+
+    public double getThreshold() {
+        return threshold;
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/config/SimilarityWeights.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/config/SimilarityWeights.java
@@ -1,0 +1,31 @@
+package com.cholog_ai.closet_saver.domain.compare.config;
+
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class SimilarityWeights {
+
+    private final Map<EmbeddingType, Double> weights;
+
+    public SimilarityWeights(final Map<EmbeddingType, Double> weights) {
+        this.weights = new EnumMap<>(Objects.requireNonNull(weights, "weights must not be null"));
+    }
+
+    public static SimilarityWeights defaultWeights() {
+        Map<EmbeddingType, Double> defaults = new EnumMap<>(EmbeddingType.class);
+        defaults.put(EmbeddingType.TEXT, 0.4);
+        defaults.put(EmbeddingType.IMAGE, 0.6);
+        return new SimilarityWeights(defaults);
+    }
+
+    public double weightFor(final EmbeddingType type) {
+        return weights.getOrDefault(type, 0.0);
+    }
+
+    public Map<EmbeddingType, Double> asMap() {
+        return Map.copyOf(weights);
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/model/ComparisonItem.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/model/ComparisonItem.java
@@ -1,0 +1,76 @@
+package com.cholog_ai.closet_saver.domain.compare.model;
+
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ComparisonItem {
+
+    private final Long id;
+    private final Map<EmbeddingType, EmbeddingValue> embeddings;
+
+    private ComparisonItem(final Long id, final Map<EmbeddingType, EmbeddingValue> embeddings) {
+        this.id = Objects.requireNonNull(id, "id must not be null");
+        this.embeddings = new EnumMap<>(Objects.requireNonNull(embeddings, "embeddings must not be null"));
+    }
+
+    public static Builder builder(final Long id) {
+        return new Builder(id);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Optional<EmbeddingValue> getEmbedding(final EmbeddingType type) {
+        return Optional.ofNullable(embeddings.get(type));
+    }
+
+    public Map<EmbeddingType, EmbeddingValue> getEmbeddings() {
+        return Map.copyOf(embeddings);
+    }
+
+    public static class Builder {
+        private final Long id;
+        private final Map<EmbeddingType, EmbeddingValue> embeddings = new EnumMap<>(EmbeddingType.class);
+
+        private Builder(final Long id) {
+            this.id = id;
+        }
+
+        public Builder textEmbedding(final EmbeddingValue embeddingValue) {
+            if (embeddingValue != null && embeddingValue.getType() != EmbeddingType.TEXT) {
+                throw new IllegalArgumentException("textEmbedding must have type TEXT");
+            }
+            if (embeddingValue != null) {
+                embeddings.put(EmbeddingType.TEXT, embeddingValue);
+            }
+            return this;
+        }
+
+        public Builder imageEmbedding(final EmbeddingValue embeddingValue) {
+            if (embeddingValue != null && embeddingValue.getType() != EmbeddingType.IMAGE) {
+                throw new IllegalArgumentException("imageEmbedding must have type IMAGE");
+            }
+            if (embeddingValue != null) {
+                embeddings.put(EmbeddingType.IMAGE, embeddingValue);
+            }
+            return this;
+        }
+
+        public Builder embedding(final EmbeddingValue embeddingValue) {
+            if (embeddingValue != null) {
+                embeddings.put(embeddingValue.getType(), embeddingValue);
+            }
+            return this;
+        }
+
+        public ComparisonItem build() {
+            return new ComparisonItem(id, embeddings);
+        }
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/model/SimilarityResult.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/model/SimilarityResult.java
@@ -1,0 +1,50 @@
+package com.cholog_ai.closet_saver.domain.compare.model;
+
+import java.util.Objects;
+
+public class SimilarityResult {
+
+    private final Long itemId;
+    private final Double textSimilarity;
+    private final Double imageSimilarity;
+    private final double combinedSimilarity;
+    private final int similarityRank;
+
+    public SimilarityResult(
+            final Long itemId,
+            final Double textSimilarity,
+            final Double imageSimilarity,
+            final double combinedSimilarity,
+            final int similarityRank
+    ) {
+        this.itemId = Objects.requireNonNull(itemId, "itemId must not be null");
+        this.textSimilarity = textSimilarity;
+        this.imageSimilarity = imageSimilarity;
+        this.combinedSimilarity = combinedSimilarity;
+        this.similarityRank = similarityRank;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public Double getTextSimilarity() {
+        return textSimilarity;
+    }
+
+    public Double getImageSimilarity() {
+        return imageSimilarity;
+    }
+
+    public double getCombinedSimilarity() {
+        return combinedSimilarity;
+    }
+
+    public int getSimilarityRank() {
+        return similarityRank;
+    }
+
+    public SimilarityResult withRank(final int rank) {
+        return new SimilarityResult(itemId, textSimilarity, imageSimilarity, combinedSimilarity, rank);
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/service/CompareService.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/service/CompareService.java
@@ -1,0 +1,87 @@
+package com.cholog_ai.closet_saver.domain.compare.service;
+
+import com.cholog_ai.closet_saver.domain.compare.config.SimilaritySettings;
+import com.cholog_ai.closet_saver.domain.compare.model.ComparisonItem;
+import com.cholog_ai.closet_saver.domain.compare.model.SimilarityResult;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+public class CompareService {
+
+    private final SimilarityCalculator similarityCalculator;
+    private final WeightedSimilarityCombiner weightedSimilarityCombiner;
+
+    public CompareService() {
+        this(new SimilarityCalculator(), new WeightedSimilarityCombiner());
+    }
+
+    public CompareService(final SimilarityCalculator similarityCalculator,
+                          final WeightedSimilarityCombiner weightedSimilarityCombiner) {
+        this.similarityCalculator = Objects.requireNonNull(similarityCalculator, "similarityCalculator must not be null");
+        this.weightedSimilarityCombiner = Objects.requireNonNull(weightedSimilarityCombiner, "weightedSimilarityCombiner must not be null");
+    }
+
+    public List<SimilarityResult> compare(final ComparisonItem anchor,
+                                          final List<ComparisonItem> candidates,
+                                          final SimilaritySettings settings) {
+        Objects.requireNonNull(anchor, "anchor must not be null");
+        Objects.requireNonNull(candidates, "candidates must not be null");
+        Objects.requireNonNull(settings, "settings must not be null");
+
+        List<SimilarityResult> results = new ArrayList<>();
+
+        for (ComparisonItem candidate : candidates) {
+            Map<EmbeddingType, Double> similarities = new EnumMap<>(EmbeddingType.class);
+
+            calculateSimilarity(anchor.getEmbedding(EmbeddingType.TEXT), candidate.getEmbedding(EmbeddingType.TEXT))
+                    .ifPresent(similarity -> similarities.put(EmbeddingType.TEXT, similarity));
+
+            calculateSimilarity(anchor.getEmbedding(EmbeddingType.IMAGE), candidate.getEmbedding(EmbeddingType.IMAGE))
+                    .ifPresent(similarity -> similarities.put(EmbeddingType.IMAGE, similarity));
+
+            if (similarities.isEmpty()) {
+                continue;
+            }
+
+            OptionalDouble combined = weightedSimilarityCombiner.combine(similarities, settings.getWeights());
+            if (combined.isEmpty() || combined.getAsDouble() < settings.getThreshold()) {
+                continue;
+            }
+
+            results.add(new SimilarityResult(
+                    candidate.getId(),
+                    similarities.get(EmbeddingType.TEXT),
+                    similarities.get(EmbeddingType.IMAGE),
+                    combined.getAsDouble(),
+                    0
+            ));
+        }
+
+        results.sort(Comparator.comparingDouble(SimilarityResult::getCombinedSimilarity).reversed());
+        List<SimilarityResult> rankedResults = new ArrayList<>();
+        int rank = 1;
+        for (SimilarityResult result : results) {
+            rankedResults.add(result.withRank(rank++));
+        }
+
+        int endIndex = Math.min(settings.getTopN(), rankedResults.size());
+        return rankedResults.subList(0, endIndex);
+    }
+
+    private Optional<Double> calculateSimilarity(final Optional<EmbeddingValue> anchorEmbedding,
+                                                 final Optional<EmbeddingValue> candidateEmbedding) {
+        if (anchorEmbedding.isEmpty() || candidateEmbedding.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(similarityCalculator.calculate(anchorEmbedding.get(), candidateEmbedding.get()));
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/service/SimilarityCalculator.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/service/SimilarityCalculator.java
@@ -1,0 +1,10 @@
+package com.cholog_ai.closet_saver.domain.compare.service;
+
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
+
+public class SimilarityCalculator {
+
+    public double calculate(final EmbeddingValue anchor, final EmbeddingValue candidate) {
+        return anchor.calculateSimilarity(candidate);
+    }
+}

--- a/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/service/WeightedSimilarityCombiner.java
+++ b/Closet-Saver/closet-saver/src/main/java/com/cholog_ai/closet_saver/domain/compare/service/WeightedSimilarityCombiner.java
@@ -1,0 +1,30 @@
+package com.cholog_ai.closet_saver.domain.compare.service;
+
+import com.cholog_ai.closet_saver.domain.compare.config.SimilarityWeights;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+
+import java.util.Map;
+import java.util.OptionalDouble;
+
+public class WeightedSimilarityCombiner {
+
+    public OptionalDouble combine(final Map<EmbeddingType, Double> similarities, final SimilarityWeights weights) {
+        double weightedSum = 0.0;
+        double totalWeight = 0.0;
+
+        for (Map.Entry<EmbeddingType, Double> entry : similarities.entrySet()) {
+            double weight = weights.weightFor(entry.getKey());
+            if (weight <= 0) {
+                continue;
+            }
+            weightedSum += entry.getValue() * weight;
+            totalWeight += weight;
+        }
+
+        if (totalWeight == 0) {
+            return OptionalDouble.empty();
+        }
+
+        return OptionalDouble.of(weightedSum / totalWeight);
+    }
+}

--- a/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/domain/compare/CompareServiceTest.java
+++ b/Closet-Saver/closet-saver/src/test/java/com/cholog_ai/closet_saver/domain/compare/CompareServiceTest.java
@@ -1,0 +1,180 @@
+package com.cholog_ai.closet_saver.domain.compare;
+
+import com.cholog_ai.closet_saver.domain.compare.config.SimilaritySettings;
+import com.cholog_ai.closet_saver.domain.compare.config.SimilarityWeights;
+import com.cholog_ai.closet_saver.domain.compare.model.ComparisonItem;
+import com.cholog_ai.closet_saver.domain.compare.model.SimilarityResult;
+import com.cholog_ai.closet_saver.domain.compare.service.CompareService;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingType;
+import com.cholog_ai.closet_saver.domain.embedding.model.vo.EmbeddingValue;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CompareServiceTest {
+
+    private final CompareService compareService = new CompareService();
+
+    @Test
+    void calculates_combined_similarity_with_available_embeddings_and_ranks() {
+        EmbeddingValue anchorText = textEmbedding(1.0);
+        EmbeddingValue anchorImage = imageEmbedding(1.0);
+
+        ComparisonItem anchor = ComparisonItem.builder(0L)
+                .textEmbedding(anchorText)
+                .imageEmbedding(anchorImage)
+                .build();
+
+        ComparisonItem fullMatch = ComparisonItem.builder(1L)
+                .textEmbedding(textEmbedding(1.0))
+                .imageEmbedding(imageEmbedding(1.0))
+                .build();
+
+        ComparisonItem partialMatch = ComparisonItem.builder(2L)
+                .textEmbedding(textEmbedding(1.0))
+                .imageEmbedding(imageEmbeddingWithOppositeHalves())
+                .build();
+
+        ComparisonItem imageOnlyStrong = ComparisonItem.builder(3L)
+                .imageEmbedding(imageEmbedding(1.0))
+                .build();
+
+        List<SimilarityResult> results = compareService.compare(
+                anchor,
+                List.of(fullMatch, partialMatch, imageOnlyStrong),
+                SimilaritySettings.defaultSettings()
+        );
+
+        assertThat(results).hasSize(3);
+        assertThat(results.get(0).getItemId()).isEqualTo(1L);
+        assertThat(results.get(0).getCombinedSimilarity()).isEqualTo(1.0);
+        assertThat(results.get(1).getItemId()).isEqualTo(3L);
+        assertThat(results.get(1).getCombinedSimilarity()).isEqualTo(1.0);
+        assertThat(results.get(2).getItemId()).isEqualTo(2L);
+        assertThat(results.get(2).getCombinedSimilarity()).isEqualTo(0.4);
+
+        assertThat(results)
+                .extracting(SimilarityResult::getSimilarityRank)
+                .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void skips_candidates_without_shared_embeddings() {
+        EmbeddingValue anchorText = textEmbedding(1.0);
+
+        ComparisonItem anchor = ComparisonItem.builder(0L)
+                .textEmbedding(anchorText)
+                .build();
+
+        ComparisonItem textMatch = ComparisonItem.builder(10L)
+                .textEmbedding(textEmbedding(1.0))
+                .build();
+
+        ComparisonItem imageOnly = ComparisonItem.builder(11L)
+                .imageEmbedding(imageEmbedding(1.0))
+                .build();
+
+        List<SimilarityResult> results = compareService.compare(
+                anchor,
+                List.of(textMatch, imageOnly),
+                SimilaritySettings.defaultSettings()
+        );
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getItemId()).isEqualTo(10L);
+        assertThat(results.get(0).getTextSimilarity()).isEqualTo(1.0);
+        assertThat(results.get(0).getImageSimilarity()).isNull();
+        assertThat(results.get(0).getCombinedSimilarity()).isEqualTo(1.0);
+    }
+
+    @Test
+    void applies_threshold_and_top_n_limits() {
+        EmbeddingValue anchorImage = imageEmbedding(1.0);
+
+        ComparisonItem anchor = ComparisonItem.builder(0L)
+                .imageEmbedding(anchorImage)
+                .build();
+
+        ComparisonItem candidateHigh = ComparisonItem.builder(21L)
+                .imageEmbedding(imageEmbedding(1.0))
+                .build();
+
+        ComparisonItem candidateMid = ComparisonItem.builder(22L)
+                .imageEmbedding(imageEmbeddingWithMixedSigns(400, 112))
+                .build();
+
+        ComparisonItem candidateLow = ComparisonItem.builder(23L)
+                .imageEmbedding(imageEmbeddingWithOppositeHalves())
+                .build();
+
+        SimilaritySettings settings = new SimilaritySettings(
+                SimilarityWeights.defaultWeights(),
+                2,
+                0.5
+        );
+
+        List<SimilarityResult> results = compareService.compare(
+                anchor,
+                List.of(candidateHigh, candidateMid, candidateLow),
+                settings
+        );
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).getItemId()).isEqualTo(21L);
+        assertThat(results.get(1).getItemId()).isEqualTo(22L);
+    }
+
+    private EmbeddingValue textEmbedding(double fillValue) {
+        double[] vector = filledVector(1536, fillValue);
+        return EmbeddingValue.builder()
+                .vector(vector)
+                .type(EmbeddingType.TEXT)
+                .build();
+    }
+
+    private EmbeddingValue imageEmbedding(double fillValue) {
+        double[] vector = filledVector(512, fillValue);
+        return EmbeddingValue.builder()
+                .vector(vector)
+                .type(EmbeddingType.IMAGE)
+                .build();
+    }
+
+    private EmbeddingValue imageEmbeddingWithOppositeHalves() {
+        double[] vector = new double[512];
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] = i < 256 ? 1.0 : -1.0;
+        }
+        return EmbeddingValue.builder()
+                .vector(vector)
+                .type(EmbeddingType.IMAGE)
+                .build();
+    }
+
+    private EmbeddingValue imageEmbeddingWithMixedSigns(int positiveCount, int negativeCount) {
+        double[] vector = new double[512];
+        for (int i = 0; i < vector.length; i++) {
+            if (i < positiveCount) {
+                vector[i] = 1.0;
+            } else if (i < positiveCount + negativeCount) {
+                vector[i] = -1.0;
+            } else {
+                vector[i] = 0.0;
+            }
+        }
+        return EmbeddingValue.builder()
+                .vector(vector)
+                .type(EmbeddingType.IMAGE)
+                .build();
+    }
+
+    private double[] filledVector(int length, double fillValue) {
+        double[] vector = new double[length];
+        for (int i = 0; i < length; i++) {
+            vector[i] = fillValue;
+        }
+        return vector;
+    }
+}


### PR DESCRIPTION
## Summary
- add compare domain configuration, models, and services to calculate weighted cosine similarities for closet items
- support optional text/image embeddings with normalized weight combination, threshold filtering, and top-N ranking
- add unit tests that validate ranking, missing-embedding handling, and configurable limits

## Testing
- ./gradlew test *(fails: dependency downloads blocked with 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427ad4b6188322926bdd8e97ee650e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 텍스트와 이미지 임베딩을 기반으로 아이템을 비교하는 유사도 계산 기능 추가
  * 유사도 점수 임계값, 가중치, 상위 N개 결과 필터링 등 비교 설정 커스터마이징 가능
  * 비교 결과에 순위 지정 및 정렬 기능 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->